### PR TITLE
Fix for start date year. WFH started in 2020 even though it feels like it was 2019

### DIFF
--- a/day-in-day-out/DateUtils.swift
+++ b/day-in-day-out/DateUtils.swift
@@ -24,7 +24,7 @@ extension Date {
     var components = DateComponents()
     components.setValue(5, for: .day)
     components.setValue(3, for: .month)
-    components.setValue(2019, for: .year)
+    components.setValue(2020, for: .year)
     return Calendar.current.date(from: components)!
   }
 }


### PR DESCRIPTION
 WFH started in 2020. Even though it feels like it has been 553 days, it started in 2019. I miss my coworkers.